### PR TITLE
make keyboard not cover edittexts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
         <activity
             android:name=".UI.MainActivity"
             android:screenOrientation="portrait" />
-        <activity android:name=".UI.RegisterActivity" />
+        <activity android:name=".UI.RegisterActivity"
+            android:windowSoftInputMode="adjustPan"/>
         <activity
             android:name=".login.LoginActivity"
             android:screenOrientation="portrait" />

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -55,7 +55,8 @@
                 android:textAlignment="viewStart"
                 android:textColor="#ffffff"
                 android:textColorHint="#ffffff"
-                android:textSize="18sp" />
+                android:textSize="18sp"
+                android:inputType="text"/>
 
             <View
                 android:layout_width="fill_parent"


### PR DESCRIPTION
Fixed by adding android:windowSoftInputMode="adjustPan" for the register activity in the manifest, now the fields move up when the keyboard opens

Also all the fields in the register activity should show the 'next' button on the keyboard now