### PR TITLE
sy100 - Figure out why "destinationLatLng" and "destinationLatLngStr" both exist in Firebase

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinCommonCompilerArguments">
+    <option name="languageVersion" value="1.1" />
+    <option name="apiVersion" value="1.1" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinCommonCompilerArguments">
-    <option name="languageVersion" value="1.1" />
-    <option name="apiVersion" value="1.1" />
-  </component>
-</project>

--- a/app/src/main/java/com/android/ubclaunchpad/driver/util/StringUtils.java
+++ b/app/src/main/java/com/android/ubclaunchpad/driver/util/StringUtils.java
@@ -23,8 +23,8 @@ public class StringUtils {
      */
     public static final String FirebaseUserEndpoint = "Users";
 
-    public static final String FirebaseDestinationLatLngEndpoint = "destinationLatLng";
-    public static final String FirebaseCurrentLatLng = "currentLatLng";
+    public static final String FirebaseDestinationLatLngEndpoint = "destinationLatLngStr";
+    public static final String FirebaseCurrentLatLng = "currentLatLngStr";
     public static final String isDriverEndpoint = "isDriver";
     public static final String numPassengersEndpoint = "seatNum";
     /**


### PR DESCRIPTION
I looked into it and it was an easy fix - our User model has a "destinationLatLngStr" field that starts out as an empty string, but when we update it we write to an endpoint hardcoded as "destinationLatLng", so it was creating a new endpoint rather than writing to "destinationLatLngStr".